### PR TITLE
chore: update use newest ubuntu for the actions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     strategy:
       fail-fast: false
@@ -21,7 +21,7 @@ jobs:
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Setup PHP & Composer
       uses: shivammathur/setup-php@v2


### PR DESCRIPTION
Update github action for newest ubuntu

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated build process to use a newer Ubuntu environment and the latest version of the checkout action in GitHub Actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->